### PR TITLE
Add JWT authentication template

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # FastAPI Project Initializer
 
-Un script Python pour générer automatiquement la structure complète d’un projet FastAPI, avec tous les dossiers, fichiers essentiels, environnement virtuel et dépendances de base.
+Un script Python pour générer automatiquement la structure complète d’un projet FastAPI, avec tous les dossiers, fichiers essentiels, un système d'authentification JWT basique, environnement virtuel et dépendances de base.
 
 ## 🚀 À quoi sert ce script ?
 
@@ -9,6 +9,7 @@ Ce script automatise :
 - La génération des fichiers principaux (`main.py`, `config.py`, etc.)
 - L’ajout d’un environnement virtuel Python
 - L’installation des dépendances nécessaires (FastAPI, Uvicorn, SQLAlchemy, etc.)
+- La mise en place d'une authentification JWT basique (email et mot de passe)
 
 ## 📁 Structure générée
 
@@ -17,11 +18,24 @@ app/
   core/
     __init__.py
     config.py
-  routes/__init__.py
-  schemas/__init__.py
-  sqlmodels/__init__.py
-  services/__init__.py
-  utils/__init__.py
+  routes/
+    __init__.py
+    auth.py
+  schemas/
+    __init__.py
+    user.py
+    token.py
+  sqlmodels/
+    __init__.py
+    user.py
+  services/
+    __init__.py
+    auth.py
+  utils/
+    __init__.py
+    dataset/
+      __init__.py
+      users.py
   middleware/__init__.py
   main.py
 venv/
@@ -48,6 +62,8 @@ README.md
 - python-dotenv
 - httpx
 - pytest
+- python-jose[cryptography]
+- passlib[bcrypt]
 
 ## ⚡ Démarrage rapide
 Après l’initialisation :


### PR DESCRIPTION
## Summary
- scaffold JWT auth route and service with email/password login
- expose JWT settings in app config
- document and install jwt dependencies in generated projects
- separate user schema and SQL model into dedicated modules
- move token models into schemas package
- seed an admin account via a generated dataset module

## Testing
- `python -m py_compile InitFastAPIProject.py`
- `python InitFastAPIProject.py <<'EOF'
 test_project
EOF`


------
https://chatgpt.com/codex/tasks/task_e_6890c535cf448323a1f0c6bc54c68b06